### PR TITLE
Citadel adapt to rules in current Unciv Vanilla

### DIFF
--- a/jsons/TileImprovements.json
+++ b/jsons/TileImprovements.json
@@ -228,7 +228,7 @@
 	{
 		"name": "Citadel",
 		"uniques": ["Gives a defensive bonus of [100]%","Deal 30 damage to adjacent enemy units","Great Improvement",
-			"Can be built outside your borders"],
+			"Can be built just outside your borders"],
 		// TODO (G&K): adds every tile around it to your territory
 	},
 


### PR DESCRIPTION
Citadel isn't buildable two or more tiles away from your borders anymore in unmodded Unciv. Maybe you want these rules to apply here too.